### PR TITLE
Temp disable threading for growth/aspect calculations, fix growth rate calc error.

### DIFF
--- a/src/cgaspects/analysis/aspect_ratios.py
+++ b/src/cgaspects/analysis/aspect_ratios.py
@@ -38,7 +38,7 @@ class AspectRatio(QWidget):
         self.selected_direction = None
         self.options: namedtuple | None = None
         self.threadpool = None
-        self.threadpool = QThreadPool()
+        #self.threadpool = QThreadPool()
         self.result_tuple = results_tuple
 
         self.signals = signals

--- a/src/cgaspects/analysis/growth_rates.py
+++ b/src/cgaspects/analysis/growth_rates.py
@@ -27,7 +27,7 @@ class GrowthRate:
         self.selected_direction = None
         self.signals = signals
         self.threadpool = None
-        self.threadpool = QThreadPool()
+        #self.threadpool = QThreadPool()
 
         self.result_tuple = results_tuple
 

--- a/src/cgaspects/gui/dialogs/growthrate_dialog.py
+++ b/src/cgaspects/gui/dialogs/growthrate_dialog.py
@@ -24,10 +24,10 @@ class GrowthRateAnalysisDialogue(QDialog):
         self.setLayout(QVBoxLayout())
         self.layout().addWidget(scroll)
 
-        # plotting_checkbox = QCheckBox("Auto-Generate Plots")
+        plotting_checkbox = QCheckBox("Auto-Generate Plots")
 
         self.selected_directions = []
-        # self.plotting_checkbox = plotting_checkbox
+        self.plotting_checkbox = plotting_checkbox
 
         """if select_all.isChecked():
             for direction in directions:


### PR DESCRIPTION
Recent change commented out plotting checkbox, resulting in error when growth rate calculation was called as the checkbox was still referenced. I've reverted that change as it was breaking the growth rate functionality entirely.

After making this change, I found that growth rate and aspect ratio calculations were still not working correctly. Sometimes they would complete, but other times they would fail to finish, leaving a random percentage on the bottom progress bar.

Narrowed this down to some issue with threading, as disabling the QThreadPools in both calculations restored consistent functionality. Resolving this threading problem is it's own issue, but for now, this PR just disables it to get the functionality back.
