### PR TITLE
Fix image exporting, Implement video generation and save.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "seaborn>=0.13.2",
     "natsort>=8.2",
     "trimesh",
+    "opencv-python>=4.5.3"
 ]
 
 [project.urls]

--- a/src/cgaspects/gui/load_ui.py
+++ b/src/cgaspects/gui/load_ui.py
@@ -471,9 +471,12 @@ class Ui_MainWindow(object):
         self.saveframe_pushButton.setObjectName(u"saveframe_pushButton")
         self.saveframe_pushButton.setEnabled(False)
         self.saveframe_pushButton.setIcon(icon3)
-
         self.verticalLayout_6.addWidget(self.saveframe_pushButton)
-
+        self.renderVideoButton = QPushButton(self.visualizationTab)
+        self.renderVideoButton.setObjectName(u"renderVideoButton") 
+        self.renderVideoButton.setEnabled(False)
+        self.renderVideoButton.setIcon(icon3)
+        self.verticalLayout_6.addWidget(self.renderVideoButton)
         self.variablesTabWidget.addTab(self.visualizationTab, "")
 
         self.verticalLayout.addWidget(self.variablesTabWidget)
@@ -693,6 +696,9 @@ class Ui_MainWindow(object):
         self.saveframe_pushButton.setStatusTip("")
 #endif // QT_CONFIG(statustip)
         self.saveframe_pushButton.setText(QCoreApplication.translate("MainWindow", u"Export graphics...", None))
+        self.renderVideoButton.setText(QCoreApplication.translate("MainWindow", u"Render Video", None))
+        self.renderVideoButton.setToolTip(QCoreApplication.translate("MainWindow", u"Render video from current frames", None))
+        self.renderVideoButton.setStatusTip(QCoreApplication.translate("MainWindow", u"Render video from current frames", None))
         self.variablesTabWidget.setTabText(self.variablesTabWidget.indexOf(self.visualizationTab), QCoreApplication.translate("MainWindow", u"Visualization", None))
 #if QT_CONFIG(tooltip)
         self.crystalInfo_groupBox.setToolTip(QCoreApplication.translate("MainWindow", u"Crystal information from the current selection", None))

--- a/src/cgaspects/gui/mainwindow.py
+++ b/src/cgaspects/gui/mainwindow.py
@@ -1,6 +1,8 @@
 import logging
 import os
 import sys
+import cv2
+import numpy as np
 from collections import defaultdict, namedtuple
 from pathlib import Path
 from typing import List
@@ -135,6 +137,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.xyz_spinBox.valueChanged.connect(self.setCurrentXYZIndex)
 
         self.saveframe_pushButton.clicked.connect(self.openglwidget.saveRenderDialog)
+        self.renderVideoButton.clicked.connect(self.render_video)
 
         self.visualizationSettings = VisualizationSettingsWidget(parent=self)
         self.visualizationSettings.setEnabled(enabled=True)
@@ -385,6 +388,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             self.openglwidget.initGeometry()
             self.actionRender.setEnabled(True)
             self.saveframe_pushButton.setEnabled(True)
+            self.renderVideoButton.setEnabled(True)
         except AttributeError as e:
             logger.warning("Initialising XYZ: No Crystal Data Found! %s", e)
 
@@ -722,8 +726,9 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.openglwidget.updateSettings(**self.visualizationSettings.settings())
         fps = self.visualizationSettings.fps()
         if self.fps != fps:
-            self.frame_timer.start(1000 // self.fps)
             self.fps = fps
+        if self.playingState:
+            self.frame_timer.start(1000 // self.fps)
 
     # Utility function to clear a layout of all its widgets
     def clear_layout(self, layout):
@@ -777,6 +782,44 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 pass
         else:
             super().keyPressEvent(event)
+    
+    def render_video(self):
+        # Get the selected framerate from the visualization settings
+        fps = self.visualizationSettings.fps()
+
+        # Ask the user for the output file name
+        file_name, _ = QFileDialog.getSaveFileName(
+            self, "Save Video", "", "Videos (*.mp4)"
+        )
+        if not file_name:
+            return
+
+        if not file_name.endswith(".mp4"):
+            file_name += ".mp4"
+
+        # Initialize the video writer
+        width = self.openglwidget.width()
+        height = self.openglwidget.height()
+        fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+        video_writer = cv2.VideoWriter(file_name, fourcc, fps, (width, height))
+
+        # Render each frame and write it to the video
+        for frame in range(len(self.frame_list)):
+            self.update_frame(frame)
+            self.openglwidget.update()
+            QtWidgets.QApplication.processEvents()
+            # Update frame counter widget
+            self.frame_slider.setValue(frame)
+            self.frame_spinBox.setValue(frame)
+            image = self.openglwidget.grabFramebuffer()
+            frame_data = bytes(image.bits())  # This converts the memoryview to bytes
+            frame_array = np.frombuffer(frame_data, dtype=np.uint8).reshape((height, width, 4))
+            frame_bgr = cv2.cvtColor(frame_array, cv2.COLOR_RGBA2BGR)
+            video_writer.write(frame_bgr)
+
+        # Release the video writer
+        video_writer.release()
+        QMessageBox.information(self, "Video Rendered", f"Video saved to {file_name}")
 
 
 def set_default_opengl_version(major, minor):

--- a/src/cgaspects/gui/visualisation/openGL.py
+++ b/src/cgaspects/gui/visualisation/openGL.py
@@ -116,7 +116,10 @@ class VisualisationWidget(QOpenGLWidget):
                 self, "Save File", "", "Images (*.png)"
             )
             if file_name:
-                self.saveRender(file_name, resolution)
+                if '.' in file_name:
+                    file_name = file_name.rsplit('.', 1)[0]
+                    logger.info("File extension incorrect, changed to .png")
+                self.saveRender(file_name+".png", resolution)
 
     def renderToImage(self, scale):
         self.makeCurrent()
@@ -137,6 +140,7 @@ class VisualisationWidget(QOpenGLWidget):
         return result
 
     def saveRender(self, file_name, resolution):
+        logger.info("Rendering %s with resolution %s", file_name, resolution)
         image = self.renderToImage(float(resolution[0]))
         image.save(file_name)
 

--- a/src/cgaspects/gui/visualisation/sphere_renderer.py
+++ b/src/cgaspects/gui/visualisation/sphere_renderer.py
@@ -6,14 +6,17 @@ from PySide6.QtOpenGL import (
     QOpenGLShaderProgram,
     QOpenGLVertexArrayObject,
 )
+from PySide6.QtGui import QOpenGLExtraFunctions
 
 
-class SphereRenderer:
+class SphereRenderer(QOpenGLExtraFunctions):
     faces = None
     vertices = None
     instances = None
 
     def __init__(self, gl):
+        super().__init__()
+        self.initializeOpenGLFunctions()
         self.vertex_shader_source = """
         #version 330 core
         layout(location = 0) in vec3 vertexPosition;
@@ -140,16 +143,7 @@ class SphereRenderer:
         self.program.release()
 
     def draw(self, gl):
-        import ctypes
-
-        ptr = ctypes.c_void_p(0)
-
-        gl.glDrawArraysInstanced(
-            GL_TRIANGLES,
-            0,
-            self.numberOfVertices(),
-            self.numberOfInstances(),
-        )
+        self.glDrawArraysInstanced(GL_TRIANGLES, 0, self.numberOfVertices(), self.numberOfInstances())
 
     def numberOfInstances(self):
         if self.instances is None:

--- a/src/cgaspects/gui/widgets/visualization_settings_widget.py
+++ b/src/cgaspects/gui/widgets/visualization_settings_widget.py
@@ -145,30 +145,34 @@ class LabelledDoubleSlider(QWidget):
         self.steps = steps
 
         self.slider = QSlider(Qt.Horizontal)
-        self.slider.setMinimum(0)
-        self.slider.setMaximum(self.steps)
-        self.slider.setSingleStep(self.step)
+        self.slider.setMinimum(self.minimum)
+        self.slider.setMaximum(self.maximum)
+        self.slider.setSingleStep(1)
+
+        self.valueLabel = QLabel(f"{self.value}")
 
         # Connect signals to slots
-        self.slider.valueChanged.connect(self.valueChanged)
+        self.slider.valueChanged.connect(self.updateValue)
 
         # Layout
         layout = QHBoxLayout()
         layout.setContentsMargins(*MARGINS)
         layout.addWidget(self.label)
         layout.addWidget(self.slider)
+        layout.addWidget(self.valueLabel)
         self.setLayout(layout)
-
-    @property
-    def step(self):
-        return (self.maximum - self.minimum) / self.steps
 
     def setValue(self, value):
         self.slider.setValue(value)
+        self.updateValue()
 
     @property
     def value(self):
-        return self.minimum + self.slider.value() * self.step
+        return self.slider.value()
+
+    def updateValue(self):
+        self.valueLabel.setText(f"{self.value}")
+        self.valueChanged.emit()
 
 
 class VisualizationSettingsWidget(QWidget):

--- a/src/cgaspects/gui/window.ui
+++ b/src/cgaspects/gui/window.ui
@@ -511,6 +511,22 @@
                <normaloff>:/material_icons/material_icons/png/content-save-custom.png</normaloff>:/material_icons/material_icons/png/content-save-custom.png</iconset>
              </property>
             </widget>
+            <widget class="QPushButton" name="renderVideoButton">
+              <property name="enabled">
+                  <bool>true</bool>
+              </property>
+              <property name="toolTip">
+                  <string>Render video of all frames</string>
+              </property>
+              <property name="text">
+                  <string>Render Video</string>
+              </property>
+              <property name="icon">
+                  <iconset resource="../../../res/qticons.qrc">
+                      <normaloff>:/material_icons/material_icons/png/video-camera.png</normaloff>
+                  </iconset>
+              </property>
+            </widget>
            </item>
           </layout>
          </widget>


### PR DESCRIPTION
# Image export was failing with error 

`/cgaspects/gui/visualisation/sphere_renderer.py", line 147, in draw
    gl.glDrawArraysInstanced(
    ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: Error calling Python override of QOpenGLWidget::paintGL(): 'PySide6.QtGui.QOpenGLFunctions' object has no attribute 'glDrawArraysInstanced'`

I've added QOpenGLExtraFunctions to give access to 'glDrawArraysInstanced'`, which resolved the error and allows for image export. Image export was also having issues if the user didn't specifically write a .png extension, so I've made it so that any passed filename will be automatically given .png extension.

# Video generation
closes #80 . I tried just recording my screen as the video played with the current implementation, but it had an inconsistent framerate. I've implemented a new button to export an mp4 video that uses the set framerate. Required adding opencv dependency. Output functions well.

![output](https://github.com/user-attachments/assets/d4c14832-3ba5-4cea-920a-5c3865e61331)